### PR TITLE
Fix: Styles for code blocks in Markdown

### DIFF
--- a/assets/css/base/_typography.scss
+++ b/assets/css/base/_typography.scss
@@ -8,22 +8,24 @@ body {
 
 ::-moz-selection {
   color: $white;
-  background: $component-active-color;
+  background: $component-active-bg;
 }
 
 ::selection {
   color: $white;
-  background: $component-active-color;
+  background: $component-active-bg;
 }
 
 pre {
   overflow: auto;
   padding: $spacer / 2;
 
+  color: $gray-500;
+  font-family: $font-family-monospace;
   font-size: map-get($font-sizes, 'md');
   white-space: pre-wrap;
 
-  background: $gray-900;
+  background: $gray-200;
   border-radius: $border-radius;
 }
 


### PR DESCRIPTION
## What happened

Change the background and font styles for the HTML tag `<pre>`.
 
## Insight

When adding code blocks in Markdown, the content was not visible:

![image](https://user-images.githubusercontent.com/696529/123391992-c62cd580-d5c6-11eb-900d-b450bb9b4249.png)

The issue was introduced in #48 🤧 
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/123392138-ec527580-d5c6-11eb-93d0-71d95de8cb03.png)